### PR TITLE
Add dataset to requirements

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -19,6 +19,7 @@ chardet==2.1.1
 ckanclient==0.10
 colormath==1.0.8
 csvkit==0.3.0
+dataset==0.5.2
 demjson==1.6
 dropbox==1.4
 errorhandler==1.1.1


### PR DESCRIPTION
I'd like to use [dataset](https://dataset.readthedocs.org/) on morph.io.

Is this the right way to request this?
